### PR TITLE
Fix append operation of identifiers with spaces and strange characters

### DIFF
--- a/redex-lib/redex/private/compiler/match.rkt
+++ b/redex-lib/redex/private/compiler/match.rkt
@@ -406,7 +406,7 @@
                          bool))
         (in-hole Context
                  (begin 
-                   (cond ((,(string->symbol (format "~s~s" (term id) '-bool)) x_1)
+                   (cond ((,(string->symbol (format "~a~a" (term id) '-bool)) x_1)
                           (matrix (x_2 ...)
                                   (((p_* ... -> r_*) eqs_* ...) ...)
                                   (pvar_2 ...)
@@ -621,7 +621,7 @@
                  (begin
                    (for
                     ((rt (parameterize ((context-match in-context))
-                           (in-list (,(string->symbol (format "~s~s" (term id) '-list)) x_1)))))
+                           (in-list (,(string->symbol (format "~a~a" (term id) '-list)) x_1)))))
                     (let ((cdr-rt (cdr rt)))
                       (matrix (cdr-rt x_2 ...)
                               (((p_* ... -> r_*) eqs_* ...) ...)
@@ -672,7 +672,7 @@
                  (begin 
                    (for
                     ((rt (parameterize ((context-match in-context))
-                           (in-list (,(string->symbol (format "~s~s" (term id) '-list)) x_1)))))
+                           (in-list (,(string->symbol (format "~a~a" (term id) '-list)) x_1)))))
                     (let ((car-rt (car rt))
                           (cdr-rt (cdr rt)))
                       (matrix (cdr-rt x_2 ...)

--- a/redex-lib/redex/private/compiler/redextomatrix.rkt
+++ b/redex-lib/redex/private/compiler/redextomatrix.rkt
@@ -303,7 +303,7 @@
             `(set! results (cons (cons ,(build-right-hand-side-helper x) '()) results))
             `(set! results (cons (cons ,(build-right-hand-side-helper x) (term ,hole-var)) results))
             )
-        `(for ((,hole-var (in-list (,(string->symbol (format "~s~s" nt-func '-list)) (term ,hole-var)))))
+        `(for ((,hole-var (in-list (,(string->symbol (format "~a~a" nt-func '-list)) (term ,hole-var)))))
               (set! results (cons (cons ,(build-right-hand-side-helper x) (cdr ,hole-var)) results))
               )
         )
@@ -419,12 +419,12 @@
          (hash-set! nt-table
                     key
                     (make-nt-struct
-                     (term (define ,(string->symbol (format "~s~s" key '-bool))
+                     (term (define ,(string->symbol (format "~a~a" key '-bool))
                              (λ (a)
                                (let ((results (list)))
                                  ,compiled-bool
                                  (and (andmap values results) (positive? (length results)))))))
-                     (term (define ,(string->symbol (format "~s~s" key '-list))
+                     (term (define ,(string->symbol (format "~a~a" key '-list))
                              (λ (a)
                                (let ((results (list)))
                                  ,compiled-set


### PR DESCRIPTION
The bug report #14761 is about an error in prefix-out when one of the identifiers has a space. The solution was to change a `"~s~s"` to `"~a~a"`.

I also looked for similar patterns in the Racket repository, and I found 6 similar instances in Redex.

I don't know enough about Redex to be sure that this is the correct fix. Please review this carefully.

(I'm moving this pull request from the Racket repository to here.)
