### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/redex-lib/info.rkt
+++ b/redex-lib/info.rkt
@@ -6,7 +6,7 @@
 
 (define deps '(("data-enumerate-lib" #:version "1.2")
                "scheme-lib"
-               "base"
+               ("base" #:version "6.2.900.6")
                "data-lib"
                "math-lib"
                "tex-table"

--- a/redex-lib/info.rkt
+++ b/redex-lib/info.rkt
@@ -12,8 +12,7 @@
                "tex-table"
                "profile-lib"
                "typed-racket-lib"
-               "unstable-2d"
-               "unstable-list-lib"))
+               "unstable-2d"))
 (define build-deps '("rackunit-lib"))
 
 (define pkg-desc "implementation (no documentation) part of \"redex\"")

--- a/redex-lib/redex/private/preprocess-pat.rkt
+++ b/redex-lib/redex/private/preprocess-pat.rkt
@@ -2,7 +2,7 @@
 
 (require racket/match
          racket/set
-         unstable/hash
+         racket/hash
 
          "env.rkt"
          "error.rkt"


### PR DESCRIPTION
Depends on Racket PR #972, which moves most of its contents to core libraries.
