### PR TITLE
Mention #:binding-forms in docs of define-language

### DIFF
--- a/redex-doc/redex/scribblings/ref/binding.scrbl
+++ b/redex-doc/redex/scribblings/ref/binding.scrbl
@@ -13,7 +13,7 @@
 
 @(define redex-eval (make-base-eval '(require redex/reduction-semantics)))
 
-@title{Binding}
+@title[#:tag "sec:binding"]{Binding}
 
 @declare-exporting[redex/reduction-semantics redex]
 

--- a/redex-doc/redex/scribblings/ref/languages.scrbl
+++ b/redex-doc/redex/scribblings/ref/languages.scrbl
@@ -16,10 +16,13 @@
 
 @defform/subs[#:literals (::=)
               (define-language lang-name 
-                non-terminal-def ...)
+                non-terminal-def ...
+                maybe-binding-spec)
               ([non-terminal-def (non-terminal-name ...+ ::= @#,ttpattern ...+)
                                  (non-terminal-name @#,ttpattern ...+)
-                                 ((non-terminal-name ...+) @#,ttpattern ...+)])]{
+                                 ((non-terminal-name ...+) @#,ttpattern ...+)]
+               [maybe-binding-spec (code:line)
+                                   (code:line #:binding-forms binding-declaration ...)])]{
 
 Defines the grammar of a language. The @racket[define-language] form supports the
 definition of recursive @|pattern|s, much like a BNF, but for
@@ -52,6 +55,9 @@ Non-terminals used in @racket[define-language] are not bound in
 @pattech[side-condition] patterns and duplicates are not constrained
 to be the same unless they have underscores in them.
 
+When @racket[maybe-binding-spec] is provided, it declares binding specifications
+for certain forms in the language. For a detailed explanation of how to declare
+and use binding specifications, see @secref["sec:binding"].
 }
 
 @defidform[::=]{
@@ -61,10 +67,13 @@ Use of the @racket[::=] keyword outside a language definition is a syntax error.
 
 @defform/subs[#:literals (::=)
               (define-extended-language extended-lang base-lang 
-                non-terminal-def ...)
+                non-terminal-def ...
+                maybe-binding-spec)
               ([non-terminal-def (non-terminal-name ...+ ::= @#,ttpattern ...+)
                                  (non-terminal-name @#,ttpattern ...+)
-                                 ((non-terminal-name ...+) @#,ttpattern ...+)])]{
+                                 ((non-terminal-name ...+) @#,ttpattern ...+)]
+               [maybe-binding-spec (code:line)
+                                   (code:line #:binding-forms binding-declaration ...)])]{
 
 Extends a language with some new, replaced, or
 extended non-terminals. For example, this language:
@@ -97,6 +106,10 @@ non-terminals to the language.
 If a language is has a group of multiple non-terminals
 defined together, extending any one of those non-terminals
 extends all of them.
+
+When @racket[maybe-binding-spec] is provided, it declares binding specifications
+for the new forms in the extended language. For a detailed explanation of how to declare
+and use binding specifications, see @secref["sec:binding"].
 }
 
 @defform/subs[(define-union-language L base/prefix-lang ...)


### PR DESCRIPTION
Adds `#:binding-forms` to the docs for `define-language` with a forwarding pointer to the binding section because I had trouble finding where binding specifications are documented. My first instinct was to look at `define-language`.