### PR TITLE
notify rackunit of tests

### DIFF
--- a/redex-lib/info.rkt
+++ b/redex-lib/info.rkt
@@ -12,6 +12,7 @@
                "tex-table"
                "profile-lib"
                "typed-racket-lib"
+               "testing-util-lib"
                "2d-lib"))
 (define build-deps '("rackunit-lib"))
 

--- a/redex-test/redex/tests/tl-test.rkt
+++ b/redex-test/redex/tests/tl-test.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require "private/test-util.rkt"
          redex/reduction-semantics
+         (only-in redex/private/reduction-semantics inform-rackunit?)
          (only-in redex/private/lang-struct make-bindings make-bind)
          racket/match
          racket/trace
@@ -15,7 +16,8 @@
 (define-syntax-rule 
   (capture-output arg1 args ...)
   (let ([p (open-output-string)])
-    (parameterize ([current-output-port p]
+    (parameterize ([inform-rackunit? #f]
+                   [current-output-port p]
                    [current-error-port p])
       arg1 args ...)
     (get-output-string p)))


### PR DESCRIPTION
Changes redex's tester to notify `rackunit/log` of tests for better integration with `raco test` and `raco cover`.