### PR TITLE
Fixed fresh after judgment-holds in reduction-rel.

### DIFF
--- a/redex-lib/redex/private/judgment-form.rkt
+++ b/redex-lib/redex/private/judgment-form.rkt
@@ -262,7 +262,7 @@
           (define-values (binding-constraints temporaries env+)
             (generate-binding-constraints output-names output-names/ellipses env orig-name))
           (define rest-body
-            (loop rest-clauses #`(list judgment-output #,to-not-be-in) env+))
+            (loop rest-clauses #`(list (term #,output-pattern) #,to-not-be-in) env+))
           (define call
             (let ([input (quasisyntax/loc premise (term #,input-template #:lang #,ct-lang))])
               (define (make-traced input)


### PR DESCRIPTION
In a reduction-relation, when fresh was used after a judgment-holds, the
output of the judgment was incorrectly referenced in the to-not-be-in
list used for computing fresh variables.