### PR TITLE
add extra constructor name to derivation, to match docs

### DIFF
--- a/redex-lib/redex/private/judgment-form.rkt
+++ b/redex-lib/redex/private/judgment-form.rkt
@@ -31,6 +31,7 @@
              syntax/stx))
 
 (struct derivation (term name subs) 
+  #:extra-constructor-name make-derivation
   #:transparent
   #:guard (λ (term name subs struct-name)
             (unless (or (not name) (string? name))


### PR DESCRIPTION
The docs claim `derivation` has an extra constructor name, so lets make it so!