### PR TITLE
Add 'disappeared-use property to judgment-form names in redex-check

### DIFF
--- a/redex-lib/redex/private/generate-term.rkt
+++ b/redex-lib/redex/private/generate-term.rkt
@@ -122,7 +122,10 @@
     [(form lang #:satisfying (jform-id . pats) property . kw-args)
      (unless (set-empty? bad-kws)
        (raise-syntax-error 'redex-check (format "~s cannot be used with #:satisfying" (car (set->list bad-kws))) stx))
-     (redex-check/jf stx #'form #'lang #'jform-id #'pats #'property #'kw-args)]
+     (syntax-property
+      (redex-check/jf stx #'form #'lang #'jform-id #'pats #'property #'kw-args)
+      'disappeared-use
+      (syntax-local-introduce #'jform-id))]
     [(form lang #:satisfying . rest)
      (raise-syntax-error 'redex-check "#:satisfying expected judgment form or metafunction syntax followed by a property" stx #'rest)]
     [(form lang pat #:enum biggest-e property . kw-args)


### PR DESCRIPTION
This change allows renaming of judgment-forms to also rename their use in the #:satisfying clause of redex-check