### PR TITLE
boolean is missing in pattern-symbols definition

### DIFF
--- a/redex-lib/redex/private/term-fn.rkt
+++ b/redex-lib/redex/private/term-fn.rkt
@@ -73,7 +73,7 @@
 (define (language-id-nt-identifiers stx id) (language-id-getter stx id 3))
 (define (language-id-nt-hole-map stx id) (language-id-getter stx id 4))
 
-(define pattern-symbols '(any number natural integer real string variable 
+(define pattern-symbols '(any number natural integer real string boolean variable
                               variable-not-otherwise-mentioned hole symbol))
 
 (define (build-disappeared-use id-stx-table nt id-stx)

--- a/redex-test/redex/tests/tl-reduction-relation.rkt
+++ b/redex-test/redex/tests/tl-reduction-relation.rkt
@@ -289,6 +289,14 @@
        1)
       '(2))
 
+;; Should not have syntax error
+(test (apply-reduction-relation
+       (reduction-relation
+        empty-language
+        #:domain boolean
+        (--> boolean_12 boolean_12))
+       #f)
+      '(#f))
 
 (test (let ([red
              (reduction-relation 


### PR DESCRIPTION
`boolean` is missing in `pattern-symbols` definition in `term-fn.rkt`.