### PR TITLE
typos

### DIFF
--- a/redex-doc/redex/scribblings/ref/other-relations.scrbl
+++ b/redex-doc/redex/scribblings/ref/other-relations.scrbl
@@ -244,7 +244,7 @@ and input positions in premises must be @|tttterm|s; input positions in conclusi
 output positions in premises must be @|ttpattern|s. When the optional @racket[contract-spec] 
 declaration is present, Redex dynamically checks that the terms flowing through
 these positions match the provided patterns, raising an exception recognized by 
-@racket[exn:fail:redex] if not. The term in the optional @racket[invariant-spec] is
+@racket[exn:fail:redex?] if not. The term in the optional @racket[invariant-spec] is
 evaluated after the output positions have been computed and the contract has matched
 successfully, with variables from the contract bound; a result of @racket[#f] is
 considered to be a contract violation and an exception is raised.

--- a/redex-doc/redex/scribblings/ref/patterns.scrbl
+++ b/redex-doc/redex/scribblings/ref/patterns.scrbl
@@ -153,7 +153,7 @@ sides of the non-terminal. If the non-terminal appears
 twice in a single pattern, then the match is constrained
 to expressions that are the same, unless the pattern is part
 of a @racket[define-language] definition or a contract (e.g., in
-@racket[define-metafunction], @racket[define-judment-form], or
+@racket[define-metafunction], @racket[define-judgment-form], or
 @racket[define-relation])
 in which case there is no constraint. Also, the
 non-terminal will be bound in the expression in any


### PR DESCRIPTION
- `exn:fail:redex?` missing the ?
- `define-judgment-form` misspelled