### PR TITLE
add 'mf-apply' keyword

### DIFF
--- a/redex-doc/redex/scribblings/ref/other-relations.scrbl
+++ b/redex-doc/redex/scribblings/ref/other-relations.scrbl
@@ -47,7 +47,8 @@
                                    (clause-name name)
                                    (code:line or @#,tttterm)])]{
 
-The @racket[define-metafunction] form builds a function on
+@deftech[#:key "metafunction"]{The} @racket[define-metafunction]
+form builds a function on
 terms according to the pattern and right-hand-side
 expressions. The first argument indicates the language used
 to resolve non-terminals in the pattern expressions. Each of

--- a/redex-doc/redex/scribblings/ref/terms.scrbl
+++ b/redex-doc/redex/scribblings/ref/terms.scrbl
@@ -22,12 +22,13 @@ the visible representation of terms.
 The grammar of @deftech{term}s is (note that an ellipsis
 stands for repetition unless otherwise indicated):
 
-@(racketgrammar* #:literals (in-hole hole unquote unquote-splicing) 
+@(racketgrammar* #:literals (in-hole hole mf-apply unquote unquote-splicing)
    [term identifier
          (term-sequence ...)
          ,expr
          (in-hole term term)
          hole
+         (mf-apply identifier term ...)
          #t #f
          string]
    [term-sequence 
@@ -59,6 +60,9 @@ the contents of the list into the expression at that point in the sequence.}
 them.}
 
 @item{A term written @racket[hole] produces a hole.}
+
+@item{A term written @racket[(mf-apply f arg ...)] asserts that @racket[f]
+is a @tech{metafunction} and produces the term @racket[(f arg ...)].}
 
 @item{A term written as a literal boolean or a string
 produces the boolean or the string.}
@@ -120,6 +124,10 @@ process that @tech{binding forms} use.
 
 @defidform[in-hole]{ Recognized specially within
   @racket[reduction-relation]. An @racket[in-hole] form is an
+  error elsewhere.  }
+
+@defidform[mf-apply]{ Recognized specially within
+  @racket[term]. A @racket[mf-apply] form is an
   error elsewhere.  }
 
 @defform/subs[(term-let ([tl-pat expr] ...) body)

--- a/redex-lib/redex/private/loc-wrapper-ct.rkt
+++ b/redex-lib/redex/private/loc-wrapper-ct.rkt
@@ -30,10 +30,13 @@
                 'init-loc-wrapper-sequence/unquoted)
           #,op #,(syntax-line stx) #,(syntax-column stx)
           others ...)))
-  (syntax-case* stx (name unquote quote unquote-splicing term) (λ (x y) (eq? (syntax-e x) (syntax-e y)))
+  (syntax-case* stx (name unquote quote unquote-splicing term mf-apply) (λ (x y) (eq? (syntax-e x) (syntax-e y)))
     ['a (reader-shorthand #'a +1 (if (= quote-depth 0) "" "'"))]
     [,a (reader-shorthand #'a -1 (if (= quote-depth 1) "" ","))]
     [,@a (reader-shorthand #'a -1 (if (= quote-depth 1) "" ",@"))]
+    [(mf-apply . e)
+     ;; do not render `mf-apply` annotations
+     (process-arg (syntax e) quote-depth)]
     [(term a)
      (if (= quote-depth 0)
          #`#(#,init-loc-wrapper/q?

--- a/redex-lib/redex/reduction-semantics.rkt
+++ b/redex-lib/redex/reduction-semantics.rkt
@@ -17,6 +17,7 @@
 (provide reduction-relation 
          --> fresh with ;; keywords for reduction-relation
          hole in-hole ;; keywords for term
+         (rename-out [#%mf-apply mf-apply]) ;; keyword for term
          ::= ;; keywords for language definition
          I O ;; keyword for define-judgment-form
          extend-reduction-relation

--- a/redex-test/redex/tests/bitmap-test.rkt
+++ b/redex-test/redex/tests/bitmap-test.rkt
@@ -315,6 +315,18 @@
 (parameterize ([delimit-ellipsis-arguments? #f])
   (btest (render-metafunction rdups) "rdups-undelimited.png"))
 
+;; using `mf-apply` should not affect the output
+(let ()
+  (define-metafunction lang
+    rdups : x ... -> (x ...)
+    [(rdups x_1 x_2 ... x_1 x_3 ...)
+     (rdups x_2 ... x_1 x_3 ...)]
+    [(rdups x_1 x_2 ...)
+     (x_1 x_3 ...)
+     (where (x_3 ...) (mf-apply rdups x_2 ...))]
+    [(rdups) ()])
+  (btest (render-metafunction rdups) "rdups-delimited.png"))
+
 ;; Non-terminal superscripts
 (btest (render-lw lang (to-lw (x_^abcdef x_q^abcdef)))
        "superscripts.png")
@@ -443,9 +455,9 @@
     [(typeof Γ (e_1 e_2) τ)
      (typeof Γ e_1 (τ_2 → τ)) (typeof Γ e_2 τ_2)]
     [(typeof Γ (λ (x : τ) e) (τ → σ))
-     (typeof (extend Γ x τ) e σ)]
+     (typeof (mf-apply extend Γ x τ) e σ)] ;; `mf-apply` shouldn't appear in the output
     [(typeof Γ x τ)
-     (where τ (lookup Γ x))])
+     (where τ (mf-apply lookup Γ x))])
   
   (define-metafunction STLC
     extend : Γ x τ -> Γ

--- a/redex-test/redex/tests/mf-apply-test.rkt
+++ b/redex-test/redex/tests/mf-apply-test.rkt
@@ -1,0 +1,173 @@
+#lang racket/base
+
+;; Test the `mf-apply` keyword:
+;; - `mf-apply` is a syntax error outside terms
+;; - `(mf-apply f e ...)` errors if `f` is not a metafunction,
+;;   otherwise is the same as `(f e ...)`
+;; - typesetting should not show `mf-apply` (in judgments or metafunctions)
+
+;; -----------------------------------------------------------------------------
+
+(require pict
+         rackunit
+         (only-in racket/class send)
+         redex/reduction-semantics
+         redex/pict
+         syntax/macro-testing
+         (for-syntax racket/base))
+
+(define expected-mf #rx"expected a previously defined metafunction")
+
+(define-language nats
+  [nat Z (S nat)])
+
+(define-syntax (fake-mf stx)
+  #'Z)
+
+(define-metafunction nats real-mf : nat -> nat
+  [(real-mf nat)
+   Z])
+
+(define-metafunction nats mf2 : nat -> nat
+  [(mf2 nat_0)
+   (S nat_1)
+   (where nat_1 (mf-apply real-mf nat_0))])
+
+(define-judgment-form nats
+  #:mode (jf I)
+  #:contract (jf nat)
+  [(where Z (mf-apply real-mf nat_0))
+   ---
+   (jf nat_0)])
+
+;; -----------------------------------------------------------------------------
+;; behavioral tests
+
+(check-exn #rx"mf-apply: used outside of term"
+  (λ () (convert-compile-time-error mf-apply))
+  "mf-apply should error when used outside `term`")
+
+(check-exn #rx"malformed mf-apply"
+  (λ () (convert-compile-time-error (term (mf-apply))))
+  "mf-apply should error when given 0 arguments")
+
+(check-exn expected-mf
+  (λ () (convert-compile-time-error (term (mf-apply yo (S Z)))))
+  "mf-apply should error when given a number")
+
+(check-exn expected-mf
+  (λ () (convert-compile-time-error (term (mf-apply 8 (S Z)))))
+  "mf-apply should error when given an unbound identifier")
+
+(check-exn expected-mf
+  (λ () (convert-compile-time-error (term (mf-apply fake-mf (S Z)))))
+  "mf-apply should error when given a syntax transformer")
+
+(check-exn expected-mf
+  (λ () (convert-compile-time-error (let ()
+          (define-metafunction nats mf2 : nat -> nat
+            [(mf2 nat_0)
+             (S nat_1)
+             (where nat_1 (mf-apply fake-mf nat_0))])
+          (void))))
+  "mf-apply should error when given a syntax transformer in a where clause")
+
+(check-exn expected-mf
+  (λ () (convert-compile-time-error (let ()
+          (define-judgment-form nats
+            #:mode (jf I)
+            #:contract (jf nat)
+            [(where Z (mf-apply fake-mf nat_0))
+             ---
+             (jf nat_0)])
+          (void))))
+  "mf-apply should error when given a syntax transformer in a judgment form premise")
+
+(check-equal?
+  (term (mf-apply real-mf (S Z)))
+  (term Z)
+  "mf-apply should apply a given metafunction")
+
+(check-equal?
+  (term (mf2 (S Z)))
+  (term (S Z)))
+
+(check-true
+  (judgment-holds (jf (S (S Z)))))
+
+;; -----------------------------------------------------------------------------
+;; typesetting tests
+
+(define (pict->pixels p)
+  (define b (pict->bitmap p))
+  (define w (send b get-width))
+  (define h (send b get-height))
+  (define pixbuf (make-bytes (* 4 (inexact->exact (ceiling (* w h))))))
+  (send b get-argb-pixels 0 0 w h pixbuf)
+  pixbuf)
+
+(define (pixels=? p1 p2)
+  (equal? (pict->pixels p1) (pict->pixels p2)))
+
+(check pixels=?
+  (term->pict nats (term (mf-apply real-mf Z)))
+  (term->pict nats (term (real-mf Z))))
+
+(check pixels=?
+  (term->pict/pretty-write nats (term (mf-apply real-mf Z)))
+  (term->pict/pretty-write nats (term (real-mf Z))))
+
+(check pixels=?
+  (metafunction->pict mf2)
+  (let () ;; mf2, without mf-apply
+    (define-metafunction nats mf2 : nat -> nat
+      [(mf2 nat_0)
+       (S nat_1)
+       (where nat_1 (real-mf nat_0))])
+    (metafunction->pict mf2)))
+
+(check pixels=?
+  (judgment-form->pict jf)
+  (let () ;; jf, without mf-apply
+    (define-judgment-form nats
+      #:mode (jf I)
+      #:contract (jf nat)
+      [(where Z (mf-apply real-mf nat_0))
+       ---
+       (jf nat_0)])
+    (judgment-form->pict jf)))
+
+;; -----------------------------------------------------------------------------
+;; lw tests
+
+;; Two lw structs that are similar --- but for occurrence of `mf-apply` ---
+;;  currently look similar, but the one with the mf-apply will have a wider
+;;  column span.
+
+(define len-mf-apply (string-length "mf-apply "))
+
+(define ((lw=? num-mf-apply) lw1 lw2)
+  (define col-span-offset (* num-mf-apply len-mf-apply))
+  (and (equal? (lw-column-span lw1) (+ (lw-column-span lw2) col-span-offset))
+       (equal? (lw-e* lw1) (lw-e* lw2))))
+
+;; lw-e* : lw -> (sexp (or/c string symbol))
+(define (lw-e* lw)
+  (define e (lw-e lw))
+  (cond
+   [(or (symbol? e) (string? e))
+    e]
+   [(list? e)
+    (for/list ([lw (in-list e)])
+      (lw-e* lw))]
+   [else
+    (raise-user-error 'mf-apply-test "expected symbol, string, or list inside lw ~a" lw)]))
+
+(check (lw=? 1)
+  (to-lw (term (mf-apply real-mf Z)))
+  (to-lw (term (real-mf Z))))
+
+(check (lw=? 2)
+  (to-lw (term (mf-apply real-mf (mf-apply real-mf (S Z)))))
+  (to-lw (term (real-mf (real-mf (S Z))))))
+

--- a/redex-test/redex/tests/run-tests.rkt
+++ b/redex-test/redex/tests/run-tests.rkt
@@ -40,6 +40,7 @@
      "core-layout-test.rkt"
      "pict-test.rkt"
      "hole-test.rkt"
+     "mf-apply-test.rkt"
      "stepper-test.rkt"
      "check-syntax-test.rkt"
      "test-docs-complete.rkt"


### PR DESCRIPTION
Sometimes when I intend to call a metafunction, I make an "unbound identifier error". For example, pretend `f` is unbound in this snippet:

```
(define-language nats (nat Z (S nat)))
(define-judgment-form nats
  #:mode (jf I)
  [....
   (where Z (f y)) ;; programmer error!
   ....
   --- Rule1
   (jf y)])
```

Since `f` is unbound, redex thinks I'm asking "does the term `Z` match the list-term `(f y)`?" and reports that this rule fails. When this happens to me, it usually takes a while to debug. But I guess that's the price to pay for function application and list patterns having the same syntax.

Not anymore! This PR adds a new "metafunction application" keyword to redex. It's an annotation in terms to tell redex "I expect a metafunction here", e.g.

```
....
(where Z (mf-apply f y))
....
```

now raises an exception unless `f` is bound in the sense of `syntax-local-value` (specifically, bound to a `term-fn?`)

Notes:
- using DrRacket also fixes my problem, but I would still like to have this keyword
- at first I wanted `#{f y}` to expand to `(mf-apply f y)`, but I didn't see how to add a readtable extension without making `#lang redex`
- I thought about adding `jf-apply` too, but `judgment-holds` and `define-judgment-form` always catch my typos. (If someone wants `jf-apply` I will add it.)
