### PR TITLE
typos

### DIFF
--- a/redex-doc/redex/scribblings/ref/typesetting.scrbl
+++ b/redex-doc/redex/scribblings/ref/typesetting.scrbl
@@ -126,7 +126,7 @@ sets @racket[dc-for-text-size] and the latter does not.
  Produces a pict like @racket[render-term], but without
  adjusting @racket[dc-for-text-size].
 
- The first argument is expected to be a @racket[compiled-language?] and
+ The first argument is expected to be a @racket[compiled-lang?] and
  the second argument is expected to be a term (without the
  @racket[term] wrapper). The formatting in the @racket[term] argument
  is used to determine how the resulting pict will look.

--- a/redex-lib/redex/private/reduction-semantics.rkt
+++ b/redex-lib/redex/private/reduction-semantics.rkt
@@ -1789,7 +1789,7 @@
                                                 `(,name ,@exp)
                                                 (if (= 1 (length mtchs))
                                                     "but"
-                                                    (format "~a different ways and "
+                                                    (format "~a different ways and"
                                                             (length mtchs))))]
                                   [else
                                    (define ans (car anss))


### PR DESCRIPTION
Fix one "broken link" in the docs and remove one extra whitespace in an error message.

Should I add a test for the error message? LIke, `(not (string-contains (exn-msg e) "  "))`. Is there a good place to put this in `redex-tests` besides making a new file `err-message-test.rkt` ?