### PR TITLE
add term-fn-id? predicate

### DIFF
--- a/redex-lib/redex/private/reduction-semantics.rkt
+++ b/redex-lib/redex/private/reduction-semantics.rkt
@@ -1232,12 +1232,10 @@
        (when (null? (syntax-e #'rest))
          (raise-syntax-error syn-error-name "no clauses" orig-stx))
        (when prev-metafunction
-         (syntax-local-value 
-          prev-metafunction
-          (λ ()
-            (raise-syntax-error 
-             syn-error-name 
-             "expected a previously defined metafunction" orig-stx prev-metafunction))))
+         (unless (term-fn-id? prev-metafunction)
+           (raise-syntax-error
+            syn-error-name
+            "expected a previously defined metafunction" orig-stx prev-metafunction)))
        (let*-values ([(contract-name dom-ctcs pre-condition 
                                      codom-contracts codomain-separators post-condition
                                      pats)

--- a/redex-test/redex/tests/gen-test.rkt
+++ b/redex-test/redex/tests/gen-test.rkt
@@ -554,6 +554,20 @@
           "didn't raise an exception")
         #rx".*generate-term:.*repeat.*"))
 
+;; errors for define-metafunction/extension with a syntax transformer
+;;  (as opposed to a metafunction, a term-fn?)
+(let ()
+  (test (with-handlers ((exn:fail? exn-message))
+          (expand
+            #'(let ()
+                (define-language L (n any))
+                (define-syntax (fake-mf stx)
+                  (syntax (term 3)))
+                (define-metafunction/extension fake-mf L
+                ((g) ()))))
+            "didn't raise an exception")
+        #rx"expected a previously defined metafunction"))
+
 (let ()
   (define-language L
     (n 1))


### PR DESCRIPTION
(these changes used to be in #83, pulled them out and added a test)

`(term-fn-id? id)` takes the `syntax-local-value` of `id` and checks that
it is a `term-fn?`

Using the predicate simplifies a few lines in `term.rkt`

It also fixes an error in `define-metafunction/extension`, which wasn't
checking whether the existing metafunction was a `term-fn?`.

For example, this program:
```
  #lang racket
  (require redex)

  (define-syntax (fake-mf stx)
    (syntax (term 1)))

  (define-language nats (nat Z (S Z)))

  (define-metafunction/extension fake-mf nats
    ((g) ()))
```

Used to raise an error like:
```
  term-fn-field0: contract violation
    expected: term-fn?
```