### PR TITLE
Update judgment-forms caches to use alpha-equivalence.

### DIFF
--- a/redex-gui-lib/redex/private/stepper.rkt
+++ b/redex-gui-lib/redex/private/stepper.rkt
@@ -66,10 +66,8 @@ todo:
     ;; all-nodes-ht : hash[sexp -o> (is-a/c node%)]
 
     (define all-nodes-ht
-      (let* ([lang (reduction-relation-lang red)]
-             [term-equal? (lambda (x y) (α-equal? (compiled-lang-binding-table lang) match-pattern x y))]
-             [term-hash (lambda (x) (α-equal-hash-code (compiled-lang-binding-table lang) match-pattern x))])
-      (make-custom-hash term-equal? term-hash)))
+      (make-α-hash (compiled-lang-binding-table (reduction-relation-lang red))
+                   match-pattern))
     
     (define root (new node%
                       [pp pp]

--- a/redex-gui-lib/redex/private/traces.rkt
+++ b/redex-gui-lib/redex/private/traces.rkt
@@ -353,9 +353,7 @@
       [(IO-judgment-form? reductions) (runtime-judgment-form-lang reductions)]))
 
   (define snip-cache
-    (let* ([term-equal? (lambda (x y) (α-equal? (compiled-lang-binding-table reductions-lang) match-pattern x y))]
-           [term-hash (lambda (x) (α-equal-hash-code (compiled-lang-binding-table reductions-lang) match-pattern x))])
-      (make-custom-hash term-equal? term-hash)))
+    (make-α-hash (compiled-lang-binding-table reductions-lang) match-pattern))
 
   ;; call-on-eventspace-main-thread : (-> any) -> any
   ;; =reduction thread=

--- a/redex-lib/redex/private/binding-forms.rkt
+++ b/redex-lib/redex/private/binding-forms.rkt
@@ -89,7 +89,7 @@ to traverse the whole value at once, rather than one binding form at a time.
 ;; == public interface ==
 
 (provide freshen α-equal? α-equal-hash-code safe-subst binding-forms-opened?
-         make-α-hash)
+         make-α-hash make-immutable-α-hash)
 
 ;; == parameters ==
 
@@ -136,6 +136,11 @@ to traverse the whole value at once, rather than one binding form at a time.
   (make-custom-hash (λ (x y) (α-equal? language-bf-table match-pattern x y))
                     (λ (x) (α-equal-hash-code language-bf-table match-pattern x))
                     (λ (x) (α-equal-secondary-hash-code language-bf-table match-pattern x))))
+
+(define (make-immutable-α-hash language-bf-table match-pattern)
+  (make-immutable-custom-hash (λ (x y) (α-equal? language-bf-table match-pattern x y))
+                              (λ (x) (α-equal-hash-code language-bf-table match-pattern x))
+                              (λ (x) (α-equal-secondary-hash-code language-bf-table match-pattern x))))
 
 ;; α-equal? : (listof (list compiled-pattern bspec))
 ;; (compiled-pattern redex-val -> (union #f mtch)) redex-val -> boolean

--- a/redex-lib/redex/private/judgment-form.rkt
+++ b/redex-lib/redex/private/judgment-form.rkt
@@ -410,12 +410,12 @@
                           (car pair-of-boxed-caches)
                           (cdr pair-of-boxed-caches)))
   (when (caching-enabled?)
-    (when (>= (hash-count (unbox boxed-cache)) cache-size)
-      (set-box! boxed-cache (make-hash))))
+    (when (>= (dict-count (unbox boxed-cache)) cache-size)
+      (set-box! boxed-cache (make-α-hash (compiled-lang-binding-table ct-lang) match-pattern))))
   (define traced (current-traced-metafunctions))
   (define cache (unbox boxed-cache))
   (define in-cache? (and (caching-enabled?)
-                         (let ([cache-value (hash-ref cache input not-in-cache)])
+                         (let ([cache-value (dict-ref cache input not-in-cache)])
                            (not (eq? cache-value not-in-cache)))))
   (define p-a-e (print-as-expression))
   (define (form-proc/cache recur input derivation-init pair-of-boxed-caches)
@@ -424,12 +424,12 @@
                    [binding-forms-opened? (if (caching-enabled?) (box #f) #f)])
       (cond
         [(caching-enabled?)
-         (define candidate (hash-ref cache input not-in-cache))
+         (define candidate (dict-ref cache input not-in-cache))
          (cond
            [(equal? candidate not-in-cache)
             (define computed-ans (form-proc recur input derivation-init pair-of-boxed-caches))
             (unless (unbox (binding-forms-opened?))
-              (hash-set! cache input computed-ans))
+              (dict-set! cache input computed-ans))
             computed-ans]
            [else
             candidate])]


### PR DESCRIPTION
This builds on #102 and should be merged after that PR. Unfortunately, this change *destroys* performance. I'm assuming I've done something wrong.