### PR TITLE
change eb1 expected test results to #true

### DIFF
--- a/redex-doc/redex/scribblings/long-tut/mon-aft.scrbl
+++ b/redex-doc/redex/scribblings/long-tut/mon-aft.scrbl
@@ -88,7 +88,7 @@ Now you can formulate language tests:
 (define eb1 (term (lambda (x x) y)))
 (define eb2 (term (lambda (x y) 3)))
 
-(test-equal (lambda? eb1) #false)
+(test-equal (lambda? eb1) #true)
 (test-equal (lambda? eb2) #false)
 
 (test-results)


### PR DESCRIPTION
Even though `y` is free, it seems the grammar allows this.  So expected results were wrong.