### PR TITLE
supply missing `in` metafunction

### DIFF
--- a/redex-doc/redex/scribblings/long-tut/mon-aft.scrbl
+++ b/redex-doc/redex/scribblings/long-tut/mon-aft.scrbl
@@ -207,7 +207,10 @@ Here are two more metafunctions that use patterns in interesting ways:
    (where #false (in x (x_1 ...)))]
   [(subtract1 (x ...) x_1) (x ...)])
 
-
+(define-metafunction Lambda
+  in : x (x ...) -> boolean
+  [(in x (x_1 ... x x_2 ...)) #true]
+  [(in x (x_1 ...)) #false])
 
 ))
 @;%


### PR DESCRIPTION
`subtract` and `subtract1` tests fail because `in` is missing.

Note: `in` is defined in `redex-doc/redex/scribblings/long-tut/code/common.rkt` --- but that file is used in a different part of the tutorial.  At this point in the tutorial the only import is `(require redex)`.