### PR TITLE
change 'returned different results' error message

### DIFF
--- a/redex-lib/redex/private/reduction-semantics.rkt
+++ b/redex-lib/redex/private/reduction-semantics.rkt
@@ -1777,11 +1777,12 @@
                                                       mtchs))))
                                 (define ht (make-hash))
                                 (for-each (λ (ans) (hash-set! ht ans #t)) anss)
+                                (define num-results (hash-count ht))
                                 (cond
                                   [(null? anss)
                                    (continue)]
-                                  [(not (= 1 (hash-count ht)))
-                                   (redex-error name "~a matched ~s ~a returned different results" 
+                                  [(not (= 1 num-results))
+                                   (redex-error name "~a matched ~s ~a returned ~a different results"
                                                 (if (< num 0)
                                                     "a clause from an extended metafunction"
                                                     (format "clause #~a (counting from 0)" num))
@@ -1789,7 +1790,8 @@
                                                 (if (= 1 (length mtchs))
                                                     "but"
                                                     (format "~a different ways and"
-                                                            (length mtchs))))]
+                                                            (length mtchs)))
+                                                num-results)]
                                   [else
                                    (define ans (car anss))
                                    (unless (for/or ([codom-compiled-pattern 

--- a/redex-test/redex/tests/tl-metafunctions.rkt
+++ b/redex-test/redex/tests/tl-metafunctions.rkt
@@ -685,7 +685,7 @@
   (test (with-handlers ([exn:fail:redex? exn-message])
           (term (f (s (s z))))
           "")
-        #rx"returned different results"))
+        #rx"returned 2 different results"))
 
 (let ()
   (define-metafunction empty-language


### PR DESCRIPTION
This is a tiny change, but it makes the error message less confusing for me.

(I thought about also printing the results, so long as there's less than 4 or them, but decided to keep it simpler.)

- - -

Here's a small program with the same problem that my code had --- the side condition was trivially passing. If anyone has ideas how to detect a bad side condition, I can try to implement that.

```
#lang racket/base
(require redex/reduction-semantics)

(define-language Nat
  (n ::= Z (S n)))

(define-metafunction Nat
  f : n -> n
  [(f n_0)
   n_1
   (judgment-holds (amb n_0 n_1))])

(define-judgment-form Nat
  #:mode (amb I O)
  [---
   (amb Z Z)]
  [
   (side-condition (not (eq? (term n) Z)))
   ---
   (amb n (S Z))])


(term (f Z))
```