### PR TITLE
doc: in-hole is allowed within terms

### DIFF
--- a/redex-doc/redex/scribblings/ref/terms.scrbl
+++ b/redex-doc/redex/scribblings/ref/terms.scrbl
@@ -123,7 +123,7 @@ process that @tech{binding forms} use.
   error elsewhere.  }
 
 @defidform[in-hole]{ Recognized specially within
-  @racket[reduction-relation]. An @racket[in-hole] form is an
+  @racket[term]. An @racket[in-hole] form is an
   error elsewhere.  }
 
 @defidform[mf-apply]{ Recognized specially within


### PR DESCRIPTION
The documentation for in-hole says:

> Recognized specially within `reduction-relation`. An in-hole form is an error elsewhere.

But this program uses `in-hole` outside a reduction-relation and works (as I hoped it would).
Tested on Racket 6.10, 6.7, 6.5, and 6.2.1.

```
#lang racket/base
(require redex/reduction-semantics)

(define-language nat
  (n ::= Z (S n))
  (E ::= hole (S E)))

(define-metafunction nat
  make-ctx : natural -> E
  [(make-ctx 0)
   hole]
  [(make-ctx natural)
   (S (make-ctx ,(- (term natural) 1)))])

(define-metafunction nat
  make-term : natural -> n
  [(make-term natural)
   (in-hole E (S Z))
   (where E (make-ctx natural))])

(term (make-term 1))
;; '(S (S Z))
```