### PR TITLE
report correct syntax location on unknown name in binding forms

### DIFF
--- a/redex-lib/redex/private/binding-forms-compiler.rkt
+++ b/redex-lib/redex/private/binding-forms-compiler.rkt
@@ -31,7 +31,9 @@
             [_ (raise-syntax-error (syntax-e form-name) "internal error")]))
 
         (define-values (pat bspec betas+ellipses)
-          (surface-bspec->pat&bspec #`(bf-name+bf-body #:exports #,exports) form-name))
+          (surface-bspec->pat&bspec
+           (quasisyntax/loc #'bf-name+bf-body (bf-name+bf-body #:exports #,exports))
+           form-name))
         
         (with-syntax ([(syncheck-expr rewritten-pat-with-betas _ _)
                        (rewrite-side-conditions/check-errs all-nts (syntax-e form-name) #t

--- a/redex-test/redex/tests/syn-err-tests/language-definition.rktd
+++ b/redex-test/redex/tests/syn-err-tests/language-definition.rktd
@@ -34,3 +34,9 @@
  ([e1 e]) (define-language L (e1 e)))
 (#rx"found a cycle of non-terminals that doesn't consume input"
  ([a1 a] [b1 b]) (define-language L (a1 ::= b) (b1 ::= a)))
+
+(#rx"unknown name imported or exported: y"
+ ([bf (λ (x) e #:refers-to y)])
+ (define-language l
+   #:binding-forms
+   bf))


### PR DESCRIPTION
```
#lang racket
(require redex/reduction-semantics)
(define-language l
  #:binding-forms
  (λ (x) e #:refers-to y))
``` 

used to report an error location deep inside of redex-lib/redex/private/binding-forms-compiler. This change causes it to point to `(λ (x) e #:refers-to y)`.