### PR TITLE
[WIP] Remove ‘cross’ from surface language

### DIFF
--- a/redex-doc/redex/scribblings/ref/patterns.scrbl
+++ b/redex-doc/redex/scribblings/ref/patterns.scrbl
@@ -36,7 +36,7 @@ identifier's lexical binding:
                pat:variable-except pat:variable-prefix
                pat:variable-not-otherwise-mentioned
                pat:hole pat:symbol pat:name pat:in-hole pat:hide-hole
-               pat:side-condition pat:cross
+               pat:side-condition
                pat:pattern-sequence pat:other-literal)
    [pattern pat:any
             pat:_
@@ -56,7 +56,6 @@ identifier's lexical binding:
             (pat:in-hole pattern pattern)
             (pat:hide-hole pattern)
             (pat:side-condition pattern guard-expr)
-            (pat:cross id)
             (pat:pattern-sequence ...)
             pat:other-literal]
    [pattern-sequence 
@@ -222,13 +221,6 @@ to match, otherwise the @pattern matches. Any
 occurrences of @racket[pat:name] in the @pattern (including those implicitly
 present via @tt{_} patterns) are bound using @racket[term-let] in
 @racket[_guard-expr]. 
-}
-
-@item{The @tt{(@defpattech[cross] @racket[_id])} @pattern is used for the compatible
-closure functions. If the language contains a non-terminal with the
-same name as @racket[_id], the @pattern @racket[(cross _id)] matches the
-context that corresponds to the compatible closure of that
-non-terminal.
 }
 
 @item{The @tt{(@defpattech[pattern-sequence] ...)}

--- a/redex-lib/redex/private/rewrite-side-conditions.rkt
+++ b/redex-lib/redex/private/rewrite-side-conditions.rkt
@@ -152,7 +152,7 @@ see also term.rkt for some restrictions/changes there
                  [under '()]
                  [under-mismatch-ellipsis '()])
         (syntax-case term (side-condition variable-except variable-prefix
-                                          hole name in-hole hide-hole cross unquote and)
+                                          hole name in-hole hide-hole unquote and)
           [(side-condition pre-pat (and))
            ;; rewriting metafunctions (and possibly other things) that have no where, etc clauses
            ;; end up with side-conditions that are empty 'and' expressions, so we just toss them here.
@@ -239,14 +239,6 @@ see also term.rkt for some restrictions/changes there
              (values #`(hide-hole #,sub-term) vars))]
           [(hide-hole a ...) (expected-exact 'hide-hole 1 term)]
           [hide-hole (expected-arguments 'hide-hole term)]
-          [(cross a)
-           (let ()
-             (expect-identifier term #'a)
-             (define a-str (symbol->string (syntax-e #'a)))
-             (values #`(cross #,(string->symbol (format "~a-~a" a-str a-str)))
-                     '()))]
-          [(cross a ...) (expected-exact 'cross 1 term)]
-          [cross (expected-arguments 'cross term)]
           [(unquote . _)
            (raise-syntax-error what "unquote disallowed in patterns" orig-stx term)]
           [_


### PR DESCRIPTION
**WORK-IN-PROGRESS · Not ready for merging**

- [x] Remove `cross` from documentation.
- [x] Remove `cross` from [`rewrite-side-conditions/check-errs`](https://github.com/racket/redex/blob/master/redex-lib/redex/private/rewrite-side-conditions.rkt#L50).
- [ ] Remove `cross` from `redex-test/redex/tests/syn-err-tests/reduction-relation-definition.rktd`.
- [ ] Make `cross` a syntax error temporarily to quantify the breakage.
- [ ] Add test cases.

Fixes https://github.com/racket/redex/issues/92