### PR TITLE
use term "piecewise" in docs

### DIFF
--- a/redex-doc/redex/scribblings/ref/other-relations.scrbl
+++ b/redex-doc/redex/scribblings/ref/other-relations.scrbl
@@ -99,7 +99,7 @@ clause to be taken.
 The @racket[clause-name] is used only when typesetting. See
 @racket[metafunction-cases].
 
-The @racket[or] clause is used to define a form of conditional
+The @racket[or] clause is used to define a form of conditional (i.e. piecewise)
 right-hand side of a metafunction. In particular, if any of the
 @racket[where] or @racket[side-condition] clauses fail, then
 evaluation continues after an @racket[or] clause, treating the


### PR DESCRIPTION
make the docs more grep-able by using the common term
"piecewise" for an `or` on the rhs of a metafun def