### PR TITLE
fix side-conditions-same-line

### DIFF
--- a/redex-pict-lib/redex/private/pict.rkt
+++ b/redex-pict-lib/redex/private/pict.rkt
@@ -225,8 +225,7 @@
                (list lhs arrow 
                      (hbl-append
                       rhs
-                      (let ([sc (rule-pict-info->side-condition-pict rp max-w)])
-                        (inset sc (min 0 (- max-rhs (pict-width sc))) 0 0 0)))
+                      (rule-pict-info->side-condition-pict rp max-w))
                      label))
               (list
                (list lhs arrow rhs label)


### PR DESCRIPTION
Current behavior of using render-reduction-relation with `#:style 'horizontal-side-conditions-same-line`:

<img width="379" alt="screen shot 2018-03-28 at 7 32 09 pm" src="https://user-images.githubusercontent.com/3662058/38061829-efae7656-32be-11e8-9927-ee0469c467ba.png">


(i.e. where clauses are underneath rule text)

behavior after changes in this PR:

<img width="477" alt="screen shot 2018-03-28 at 7 34 53 pm" src="https://user-images.githubusercontent.com/3662058/38061863-297557ec-32bf-11e8-83b9-793ea64c593d.png">


(i.e. where clauses now correctly appear to the right of the rules)