### PR TITLE
Implement redex-define

### DIFF
--- a/redex-doc/redex/scribblings/ref/terms.scrbl
+++ b/redex-doc/redex/scribblings/ref/terms.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/manual
 @(require "common.rkt"
+          scribble/example
           (for-label racket/base
                      (except-in racket/gui make-color)
                      racket/pretty
@@ -9,6 +10,8 @@
                      (only-in pict pict? text dc-for-text-size text-style/c
                               vc-append hbl-append vl-append)
                      redex))
+
+@(define redex-eval (make-base-eval '(require redex/reduction-semantics)))
 
 @title{Terms}
 
@@ -182,8 +185,32 @@ In some contexts, it may be more efficient to use @racket[term-match/single]
 The @racket[let*] analog of @racket[redex-let].
 }
 
+@defform[(redex-define language @#,ttpattern expression)]{
+ The @racket[define] analog of @racket[redex-let].
+ The form @racket[redex-define] evaluates @racket[_expression],
+ matches the result against @|ttpattern|
+ and binds the corresponding identifiers.
+
+ The form @racket[redex-define] cannot bind identifiers with ellipses.
+
+ @examples[#:eval
+           redex-eval
+           (define-language nums
+             (AE number
+                 (+ AE AE)))
+           (redex-define nums (name AE_all (+ AE_common AE_common)) (term (+ 4 4)))
+           (term (AE_all AE_common))
+           (eval:error (redex-define nums (+ AE_same AE_same) (term (+ 6 3))))
+           (eval:error (redex-define nums (number ...) (term (2 1 7))))
+ ]
+
+ @history[#:added "1.13"]
+}
+
 @defform[(define-term identifier @#,tttterm)]{
-Defines @racket[identifier] for use in @|tterm| templates.}
+Defines @racket[identifier] for use in @|tterm| templates.
+To pattern match and bind identifiers against @|tttterm|,
+see @racket[redex-define].}
 
 @defform[(term-match language [@#,ttpattern expression] ...)]{
 

--- a/redex-lib/redex/reduction-semantics.rkt
+++ b/redex-lib/redex/reduction-semantics.rkt
@@ -55,6 +55,7 @@
          (rename-out [test-match? redex-match?])
          term-match
          term-match/single
+         redex-define
          redex-let
          redex-let*
          define-term

--- a/redex-test/redex/tests/tl-language.rkt
+++ b/redex-test/redex/tests/tl-language.rkt
@@ -6,6 +6,7 @@
                   compiled-lang-lang compiled-lang-cclang
                   nt-rhs nt-name rhs-pattern)
          racket/match
+         syntax/macro-testing
          (for-syntax redex/private/term-fn racket/base))
 
 (define-namespace-anchor ns-anchor)
@@ -720,6 +721,39 @@
         (term ((("1" "2") ("1" "2"))
                (("1" "2") ("1" "2"))
                (("1" "2") ("1" "2"))))))
+
+(let ()
+  (define-language L
+    (nt ::= number (s-exp boolean nt)))
+
+  (define s-exp (term (s-exp #t 5)))
+
+  (test (begin
+          (redex-define L nt s-exp)
+          (term nt))
+        (term (s-exp #t 5)))
+
+  (test (begin
+          (redex-define L (s-exp #t nt) s-exp)
+          (term nt))
+        (term 5))
+
+  (test (with-handlers ([exn:fail:redex? exn-message])
+          (redex-define empty-language #t #f)
+          (void))
+        "redex-define: term #f does not match pattern #t")
+
+  (test (with-handlers ([exn:fail:redex? exn-message])
+          (redex-define empty-language (_ ... integer _ ...) (list 0 1))
+          (void))
+        "redex-define: pattern (_ ... integer _ ...) matched term (0 1) multiple ways")
+
+  (test (with-handlers ([exn:fail:syntax? exn-message])
+          (convert-syntax-error
+           (let ()
+             (redex-define empty-language (any ...) (list 1 2))
+             (void))))
+        "redex-define: defining identifiers under ellipses is not supported"))
 
 (let ()
   (define-language A


### PR DESCRIPTION
This pull request implements a limited form of `redex-define`.

`term` is implemented using `datum`. Since there's no `define/with-datum`, I don't see an easy way to support variables with ellipses in `redex-define`. The current implementation of `redex-define` signals a syntax error upon encountering ellipses.
