### PR TITLE
Propagate source location information in the expansion of test forms

### DIFF
--- a/redex-lib/redex/private/reduction-semantics.rkt
+++ b/redex-lib/redex/private/reduction-semantics.rkt
@@ -1218,7 +1218,9 @@
                        [name (syntax-local-infer-name stx)])
            #`(begin
                syncheck-expr
-               (do-test-match lang-exp `side-condition-rewritten 'binders 'name #,boolean-only?)))))]
+               #,(quasisyntax/loc stx
+                   (do-test-match lang-exp `side-condition-rewritten
+                                  'binders 'name #,boolean-only?))))))]
     [(form-name lang-exp pattern expression)
      (identifier? #'lang-exp)
      (syntax 
@@ -2958,12 +2960,13 @@
            e1:expr
            e2:expr ...)
      #:declare equiv? (expr/c test-equiv-ctc #:name test-equiv-name)
-     #`(test-->>/procs 'test-->> red (λ () e1) (λ () (list e2 ...))
+     (quasisyntax/loc stx
+       (test-->>/procs 'test-->> red (λ () e1) (λ () (list e2 ...))
                        traverse-reduction-graph
                        #,(attribute cycles-ok?)
                        equiv?.c
                        #,(attribute pred)
-                       #,(get-srcloc stx))]))
+                       #,(get-srcloc stx)))]))
 
 (define-syntax (test--> stx)
   (syntax-parse stx
@@ -2973,9 +2976,10 @@
            e1:expr
            e2:expr ...)
      #:declare equiv? (expr/c test-equiv-ctc #:name test-equiv-name)
-     #`(test-->>/procs 'test--> red (λ () e1) (λ () (list e2 ...))
+     (quasisyntax/loc stx
+       (test-->>/procs 'test--> red (λ () e1) (λ () (list e2 ...))
                        apply-reduction-relation/dummy-second-value
-                       #t equiv?.c #f #,(get-srcloc stx))]))
+                       #t equiv?.c #f #,(get-srcloc stx)))]))
 
 (define (apply-reduction-relation/dummy-second-value red arg #:visit visit)
   (values (apply-reduction-relation red arg) #f))
@@ -3043,7 +3047,8 @@
                             #:name "goal expression")
      #:declare steps (expr/c #'(or/c natural-number/c +inf.0) 
                              #:name "steps expression")
-     #`(test-->>∃/proc relation.c start goal.c steps.c #,(get-srcloc stx))]))
+     (quasisyntax/loc stx
+       (test-->>∃/proc relation.c start goal.c steps.c #,(get-srcloc stx)))]))
 
 (define (test-->>∃/proc relation start goal steps srcinfo)
   (let ([result (traverse-reduction-graph 
@@ -3117,12 +3122,13 @@
             [else orig-jf-stx]))
         #`(begin
             #,syncheck-exprs
-            (test-judgment-holds/proc (λ () (judgment-holds #,jf-stx (#,@(reverse any-vars))))
-                                      'jf
-                                      #,(judgment-form-lang a-judgment-form)
-                                      `(list #,@(reverse pats))
-                                      #,(get-srcloc stx)
-                                      #,(not mode)))]
+            #,(quasisyntax/loc stx
+                (test-judgment-holds/proc (λ () (judgment-holds #,jf-stx (#,@(reverse any-vars))))
+                                          'jf
+                                          #,(judgment-form-lang a-judgment-form)
+                                          `(list #,@(reverse pats))
+                                          #,(get-srcloc stx)
+                                          #,(not mode))))]
        [else
         ;; this case should always result in a syntax error
         #`(judgment-holds #,orig-jf-stx)])]))
@@ -3157,7 +3163,8 @@
 (define-syntax (test-predicate stx)
   (syntax-case stx ()
     [(_ p arg)
-     #`(test-predicate/proc p arg #,(get-srcloc stx))]))
+     (quasisyntax/loc stx
+       (test-predicate/proc p arg #,(get-srcloc stx)))]))
 
 (define (test-predicate/proc pred arg srcinfo)
   (cond
@@ -3193,9 +3200,11 @@
 (define-syntax (test-equal stx)
   (syntax-case stx ()
     [(_ e1 e2)
-     #`(test-equal/proc e1 e2 #,(get-srcloc stx) #,test-equiv-default)]
+     (quasisyntax/loc stx
+       (test-equal/proc e1 e2 #,(get-srcloc stx) #,test-equiv-default))]
     [(_ e1 e2 #:equiv ~equal?)
-     #`(test-equal/proc e1 e2 #,(get-srcloc stx) ~equal?)]))
+     (quasisyntax/loc stx
+       (test-equal/proc e1 e2 #,(get-srcloc stx) ~equal?))]))
 
 (define (test-equal/proc v1 v2 srcinfo equal?)
   (cond

--- a/redex-test/redex/tests/private/test-util.rkt
+++ b/redex-test/redex/tests/private/test-util.rkt
@@ -45,12 +45,12 @@
     [else
      (printf "~a: ~a test~a failed.\n" filename failures (if (= 1 failures) "" "s"))]))
 
-(define (test/proc run expected line filename)
+(define (test/proc run expected line filename [=? matches?])
   ;(printf "testing line ~s:~s\n" filename line)
   (let ([got (with-handlers ((exn:fail? values)) (run))])
     (set! tests (+ tests 1))
     (unless (and (not (exn? got))
-                 (matches? got expected))
+                 (=? got expected))
       (set! failures (+ 1 failures))
       (eprintf "test: file ~a line ~a:\n     got ~s\nexpected ~s\n"
                filename

--- a/redex-test/redex/tests/run-err-tests/test-equal.rktd
+++ b/redex-test/redex/tests/run-err-tests/test-equal.rktd
@@ -1,0 +1,4 @@
+("bang"
+ ([bad-test (test-equal #f #f)])
+ (parameterize ([default-equiv (λ (a b) (error "bang"))])
+   bad-test))

--- a/redex-test/redex/tests/run-err-tests/test-judgment-holds.rktd
+++ b/redex-test/redex/tests/run-err-tests/test-judgment-holds.rktd
@@ -1,0 +1,4 @@
+(#rx"^ctc-fail: judgment input values do not match its contract;\n"
+ ([bad-use (ctc-fail #t #f)]
+  [bad-test (test-judgment-holds bad-use)])
+ bad-test)

--- a/redex-test/redex/tests/run-err-tests/test-predicate.rktd
+++ b/redex-test/redex/tests/run-err-tests/test-predicate.rktd
@@ -1,0 +1,3 @@
+("bang"
+ ([bad-test (test-predicate (λ (x) (error "bang")) #f)])
+ bad-test)

--- a/redex-test/redex/tests/run-err-tests/test-reduction-relation.rktd
+++ b/redex-test/redex/tests/run-err-tests/test-reduction-relation.rktd
@@ -1,0 +1,29 @@
+("reduction-relation: relation not defined for #f"
+ ([bad-test (test--> inc (term #f) (term #t))])
+ (let ()
+   (define-language L)
+   (define inc
+     (reduction-relation
+      L #:domain integer
+      (--> integer ,(add1 (term integer)))))
+   bad-test))
+
+("reduction-relation: relation not defined for #f"
+ ([bad-test (test-->> inc (term #f) (term #t))])
+ (let ()
+   (define-language L)
+   (define inc
+     (reduction-relation
+      L #:domain integer
+      (--> integer ,(add1 (term integer)))))
+   bad-test))
+
+("reduction-relation: relation not defined for #f"
+ ([bad-test (test-->>∃ inc (term #f) (term #t))])
+ (let ()
+   (define-language L)
+   (define inc
+     (reduction-relation
+      L #:domain integer
+      (--> integer ,(add1 (term integer)))))
+   bad-test))

--- a/redex-test/redex/tests/syn-err-tests/term.rktd
+++ b/redex-test/redex/tests/syn-err-tests/term.rktd
@@ -1,8 +1,8 @@
 (#rx"missing ellipsis"
- ([id-no-ellipsis x]) ([ellipsis ...])
- (term-let ([(id-no-ellipsis ellipsis) '(a b c)]) (term id-no-ellipsis)))
+ ([id-no-ellipsis x])
+ (term-let ([(id-no-ellipsis ...) '(a b c)]) (term id-no-ellipsis)))
 
 (#rx"too few ellipses"
  ([bound x]) ([bind x])
- (... (term-let ([((bind ...) ...) '()])
-                (term (bound ...)))))
+ (term-let ([((bind ...) ...) '()])
+           (term (bound ...))))


### PR DESCRIPTION
When an error occurs during the evaluation of a test like `test-->>` (that is *not* merely the test failing), the error is currently reported in terms of an internal location inside of redex, even when errortrace is enabled:

```racket
#lang racket

(require redex)

(define-language L
  [e ::= explode (e e)]
  [E ::= hole (E e) (e E)])

(define reduce-e
  (reduction-relation
   L
   #:domain e
   (--> (in-hole E explode)
        (in-hole E (explode explode)))))

(test-->>
 reduce-e
 (term not-a-valid-term))
```
```
gits/racket/redex/redex-lib/redex/private/reduction-semantics.rkt:2961:7: reduction-relation: relation not defined for not-a-valid-term
```

With this change, errortrace can instead pinpoint the error location to the test in the user’s code.