### PR TITLE
doc: add history note for #:codomain

### DIFF
--- a/redex-doc/redex/scribblings/ref/reduction-relations.scrbl
+++ b/redex-doc/redex/scribblings/ref/reduction-relations.scrbl
@@ -176,6 +176,8 @@ where the @tt{==>} shortcut is defined by reducing in the context
 A @racket[fresh] clause in @racket[reduction-case] defined by shortcut
 refers to the entire term, not just the portion matched by the left-hand
 side of shortcut's use.
+
+@history[#:changed "1.14" @elem{Added the @racket[#:codomain] clause.}]
 }
 
 @defform[(extend-reduction-relation reduction-relation language more ...)]{

--- a/redex-lib/redex/HISTORY.txt
+++ b/redex-lib/redex/HISTORY.txt
@@ -17,6 +17,7 @@ v6.12
 v6.11
 
   * various bug fixes
+  * added #:codomain clause to `reduction-relation`
 
 v6.10
 


### PR DESCRIPTION
Add a `@history` note for https://github.com/racket/redex/commit/9e1d31b8720d671f3d9f3ba708853b89ceac0b33

(After writing this, I realize `#:binding-forms` could also use a history note)