### PR TITLE
Fix promise re-entrance

### DIFF
--- a/redex-test/redex/tests/enum-test.rkt
+++ b/redex-test/redex/tests/enum-test.rkt
@@ -202,3 +202,15 @@
     (define i2 (to-nat e/e t))
     (unless (= i i2)
       (error 'bad-index "~s -> ~s -> ~s" i t i2))))
+
+
+(let ()
+  (define-language nested-finite-cross
+    (b ::= (:= e))
+    (e ::= 1))
+
+  (check-not-exn
+   (lambda ()
+     ((generate-term nested-finite-cross (cross b) #:i-th)
+      1)))
+  (try-it nested-finite-cross (cross b)))


### PR DESCRIPTION
When enumerating a cross pattern for a language with non-recursive non-terminals that refer to other
non-recursive non-terminals, the enumerations for those non-terminal are not delayed,
which causes the whole cc-enum table to be re-forced too early. This is because in the compatible-closure-language there will be a non-terminal which will be non-recursive, but still refer to a `cross`, so compiling it will look at (and force) the cc-enum table immediately.

There are two other ways to fix this that might be better, but they have issues.

The enumerations for the fin-langs could be `delay/e`ed, but we don't know what the sizes of the enumerations will be, and `+inf.0` is probably a lie.

The compatible-closure-language generation could be changed to never insert a `(cross nt)` for any `nt` which isn't recursive, and instead to insert a `hole`, but I don't understand why the compatible-closure-language generation works the way it does, so I don't know if this would break other invariants.