### PR TITLE
Fix redex-let error messages.

### DIFF
--- a/redex-lib/redex/private/reduction-semantics.rkt
+++ b/redex-lib/redex/private/reduction-semantics.rkt
@@ -114,10 +114,9 @@
 (define ((term-match/single/proc form-name lang ps0 cps rhss) term)
   (let loop ([ps ps0] [cps cps] [rhss rhss])
     (if (null? ps)
-        (redex-error form-name 
-                     (if (null? (cdr ps0))
-                         (format "term ~s does not match pattern ~s" term (car ps0))
-                         (format "no patterns matched ~s" term)))
+        (if (null? (cdr ps0))
+            (redex-error form-name "term ~s does not match pattern ~s" term (car ps0))
+            (redex-error form-name "no patterns matched ~s" term))
         (let ([match (match-pattern (car cps) term)])
           (if match
               (begin

--- a/redex-test/redex/tests/tl-language.rkt
+++ b/redex-test/redex/tests/tl-language.rkt
@@ -583,6 +583,11 @@
                    (term (number_1 6) #:lang L))
         '(5 6)))
 
+(test (with-handlers ([exn:fail:redex? exn-message])
+        (redex-let empty-language ([~PATTERN 'TERM])
+          "no error"))
+      #rx"pattern ~PATTERN")
+
 ;; make sure the "before underscore" check works (no syntax error)
 (let ()
   (define-extended-language L2 empty-language [(τ υ) whatever])


### PR DESCRIPTION
The actual error message was accidentally
passed as the format string to `redex-error`.