### PR TITLE
[WIP] add redex-rackunit-adapter-lib

### DIFF
--- a/redex-rackunit-adapter-lib/info.rkt
+++ b/redex-rackunit-adapter-lib/info.rkt
@@ -1,0 +1,9 @@
+#lang setup/infotab
+
+(define collection 'multi)
+
+(define deps '("redex-lib" "rackunit"))
+
+(define pkg-desc "PLT Redex libraries for practical semantics engineering")
+
+(define pkg-authors '(florence))

--- a/redex-rackunit-adapter-lib/redex/rackunit-adapter.rkt
+++ b/redex-rackunit-adapter-lib/redex/rackunit-adapter.rkt
@@ -1,0 +1,149 @@
+#lang racket
+(provide
+ (rename-out
+  [in:test-->* test-->]
+  [in:test-->>* test-->>]
+  [in:test-judgment-holds test-judgment-holds]
+  [in:test-equal test-equal])
+ test-judgment-does-not-hold
+ test-->>∃
+ test--/>
+ test--?>
+ test-->>P
+ test-->>P*)
+(require redex/reduction-semantics
+         rackunit
+         (for-syntax syntax/parse)
+         syntax/parse/define
+         (for-syntax rackunit-abbrevs/error-reporting))
+
+(define-syntax in:test-->*
+  (syntax-parser
+    [(_ R term results ...)
+     (syntax/loc this-syntax
+       (test--> R term (list results ...)))]))
+
+(define-syntax in:test-->>*
+  (syntax-parser
+    [(_ R term results ...)
+     (syntax/loc this-syntax
+       (test-->> R term (list results ...)))]))
+
+(define-check (test--> R term expected)
+  (define res (apply-reduction-relation R term))
+  (unless (equal? (list->set res)
+                  (list->set expected))
+    (with-check-info
+     (['results res]
+      ['expected expected])
+     (fail-check "Did not match reductions in one step"))))
+
+(define-check (test-->> R term results ...)
+  (define res (apply-reduction-relation* R term))
+  (define expected (list results ...))
+  (unless (equal? (list->set res)
+                  (list->set expected))
+    (with-check-info
+     (['results res]
+      ['expected expected])
+     (fail-check "Did not match reductions in many"))))
+
+(define-check (test-->>∃ R term expected)
+  (define res (apply-reduction-relation* R term #:all? #t))
+  (unless (memf (curry (default-equiv) expected) res)
+    (with-check-info
+     (['results res]
+      ['expected expected])
+     (fail-check "could not find term not match reductions in many steps"))))
+
+(define-check (test--/> R term)
+  (define res (apply-reduction-relation R term))
+  (unless (empty? res)
+    (with-check-info
+     (['results res])
+     (fail-check "could not find term not match reductions in many steps"))))
+
+(define-check (test--?> R term t)
+  (define res (apply-reduction-relation R term))
+  (if t
+      (when (empty? res)
+        (fail-check "had no reductions when it should have"))
+      (unless (empty? res)
+        (with-check-info
+         (['results res])
+         (fail-check "could not find term not match reductions in many steps")))))
+
+(define-check (test-->>P R term P)
+  (define res (apply-reduction-relation* R term))
+  (define failed
+    (for/list ([r (in-list res)]
+               #:unless (P r))
+      r))
+  (unless (empty? failed)
+    (with-check-info
+     (['all-results res]
+      ['failed failed])
+     (fail-check "Some terminal reductions failed property"))))
+
+(define-check (test-->>P* R term P)
+  (define res (apply-reduction-relation* R term))
+  (define failed (P res))
+  (unless failed
+    (with-check-info
+     (['all-results res])
+     (fail-check "Some terminal reductions failed property"))))
+
+(define-syntax in:test-equal
+  (syntax-parser
+    [(test-equal a b)
+     (syntax/loc this-syntax
+       (test-equal a b #:equiv (default-equiv)))]
+    [(test-equal a b #:equiv eq)
+     #`(with-default-check-info*
+        (list (make-check-name 'test-equial)
+              (make-check-location '#,(syntax->location this-syntax))
+              (make-check-expression
+               '(test-equal a b #:equiv eq)))
+        (lambda ()
+          ((current-check-around)
+           (lambda ()
+             (define a* a)
+             (define b* b)
+             (unless (eq a* b*)
+               (with-check-info
+                (['expected a*]
+                 ['actual b*])
+                (fail-check)))))))]))
+
+(define-syntax test-judgment-does-not-hold
+  (syntax-parser
+    [(test-judgment-does-not-hold (judgment body ...))
+     #`(with-default-check-info*
+        (list (make-check-name 'test-judgment-does-not-hold)
+              (make-check-location '#,(syntax->location this-syntax))
+              (make-check-expression
+               '(test-judgment-doesnt-hold (judgment body ...))))
+        (lambda ()
+          ((current-check-around)
+           (lambda ()
+             (define r (judgment-holds (judgment body ...) (body ...)))
+             (with-check-info
+              (['|held at| (map (lambda (x) (cons 'judgment x)) r)])
+              (unless (empty? r)
+                (fail-check "judgment, in fact, held")))))))]))
+
+(define-syntax in:test-judgment-holds
+  (syntax-parser
+    [(test-judgment-doesnt-hold (judgment body ...))
+     #`(with-default-check-info*
+        (list (make-check-name 'test-judgment-doesnt-hold)
+              (make-check-location '#,(syntax->location this-syntax))
+              (make-check-expression
+               '(test-judgment-doesnt-hold (judgment body ...))))
+        (lambda ()
+          ((current-check-around)
+           (lambda ()
+             (define r (judgment-holds (judgment body ...)))
+             (when (not r)
+               (fail-check "judgment didn't hold"))))))]))
+


### PR DESCRIPTION
This PR adds a new redex library that integrates better with rackunit. It's still very much a WIPthe purpose of this PR 1) get feedback on other ways to integration rackunit, 2) to decide if any of the features here should be moved into redex proper, 3) to decide if this should be added here or as a stand alone package.

The changes this makes are as follows

All test-* forms have been updated to:
1. integrate with the control-flow properties of `test-begin`, `test-case`, and `test-suite`.
2. invoke the `(error-display-handler)` to get a clickable button that will jump to the failed test (this is called indirectly via rackunit).
3. Test failures use rackunit style prints. For example:
```
> (redex:test-equal 1 2 #:equiv equal?)
FAILED :5.2
  actual: 1
expected: 2
> (racknit:test-equal 1 2 #:equiv equal?)
--------------------
. FAILURE
name:       test-equal
location:   interactions from an unsaved editor:9:2
expected:   1
actual:     2
--------------------
```
and
```
> (define-language L)
> (define-judgment-form L
    #:mode (nat? I)
    [--------
     (nat? natural)])
> (redex:test-judgment-holds (nat? "a"))
FAILED :24.2
  judgment of nat? does not hold
> (rackunit:test-judgment-holds (nat? "a"))
--------------------
. FAILURE
name:       rackunit:test-judgment-holds
location:   interactions from an unsaved editor:27:2

judgment didn't hold
--------------------
```

In addition the following test forms are added:

- `test-judgment-does-not-hold` : tests that a judgment does not hold
- `test--/>` : tests that a term does not reduce
- `test-->>P` : a combination of `test-->>` and `test-predicate`, which tests
if all reachable terms hold for some property P 
- `test-->>P*`: like `test-->>P`, but the predicate is give the list of all terms


Examples of test failures for new forms:
`test-judgment-does-not-hold`
```
> (define-judgment-form L
    #:mode (buggy-rest I O)
    [----
     (buggy-rest () nil)]
    [----
     (buggy-rest (any any_1 ...) (any_1 ...))])
> (test-judgment-does-not-hold (buggy-rest () any))
--------------------
. FAILURE
name:       test-judgment-does-not-hold
location:   interactions from an unsaved editor:22:2
held at:    ((buggy-rest () nil))
--------------------
```
`test--/>`
```
> (define R (reduction-relation L (--> any any)))
> (test--/> R 1)
--------------------
. FAILURE
name:       test--/>
location:   interactions from an unsaved editor:5:2
params:     '(#<reduction-relation> 1)
results:    (1)

term reduced
--------------------
```
`test-->>P` 
```
> (define R1 (reduction-relation L (--> natural ,(~a (term natural)))))
> (test-->>P R1 1 natural?)
--------------------
. FAILURE
name:         test-->>P
location:     interactions from an unsaved editor:16:2
params:       '(#<reduction-relation> 1 #<procedure:natural?>)
all-results:  ("1")
failed:       ("1")

Some terminal reductions failed property
--------------------
```
`test-->>P*` 

```
> (define R2
    (reduction-relation
     L
     (--> natural natural)))
> (test-->>P*
   R2 1
   (lambda (x) (= (length x) 1)))
--------------------
. FAILURE
name:         test-->>P*
location:     interactions from an unsaved editor:78:2
params:       '(#<reduction-relation> 1 #<procedure>)
all-results:  ()

Some terminal reductions failed property
--------------------
```

A TODO list:

[ ] Write docs
[ ] write tests
[ ] use internal test-judgment-holds that redex uses  to improve error messages
[ ] extend test-judgment-holds to have the same interface as redex proper
[ ] extend test-judgment-does-not-hold to have the same interface as redex proper
[ ] extend test--> to have the same interface as redex proper
[ ] extend test-->> to have the same interface as redex proper
[ ] extend test-->>∃ to have the same interface as redex proper
[ ] add test-->>E
[ ] add test-predicate
[ ] change test-equal to no show the `#:equiv` when non is provided
[ ] add `test-->P` and `test-->P*`
[ ] update error message to instead of giving stuff like `(#<reduction-relation> 1 #<procedure:natural?>)`, to give `(R1 1 natural?)`