### PR TITLE
Fixes #212.

### DIFF
--- a/redex-lib/redex/private/cycle-check.rkt
+++ b/redex-lib/redex/private/cycle-check.rkt
@@ -32,7 +32,8 @@
             (equal? nt nt2))))
       (unless in-ntss?
         (hash-set! nt-hole-at-top nt ans)
-        (hash-set! nt-neighbors nt (hash-ref parent-language-nt-neighbors nt)))))
+        (hash-set! nt-neighbors nt (hash-ref parent-language-nt-neighbors
+                                             (hash-ref aliases nt nt))))))
 
   (when parent-language-nt-neighbors
     (for ([(nt _) (in-hash parent-language-nt-neighbors)])

--- a/redex-test/redex/tests/tl-language.rkt
+++ b/redex-test/redex/tests/tl-language.rkt
@@ -6,6 +6,7 @@
                   compiled-lang-lang compiled-lang-cclang
                   nt-rhs nt-name rhs-pattern)
          racket/match
+         syntax/macro-testing
          (for-syntax redex/private/term-fn racket/base))
 
 (define-namespace-anchor ns-anchor)
@@ -43,6 +44,16 @@
              (loop pat))]
           [_ (void)]))))
   not-really-nts)
+
+(test
+ (void)
+ (with-handlers ([exn:fail? values])
+   (convert-compile-time-error
+    (let ()
+      (define-language base-language
+        [NT ALIAS ::= hole])
+      (define-extended-language extended-language base-language)
+      (void)))))
 
 (define-language empty-language)
 


### PR DESCRIPTION
Consult the `aliases` table before looking up non-terminals in `parent-language-nt-neighbors`.

Based on the [comments](https://github.com/racket/redex/blob/96ef2080ffaa42ccfc3d45786915227c65a9b3d2/redex-lib/redex/private/cycle-check.rkt#L21-L25) and the [usage](https://github.com/racket/redex/blob/96ef2080ffaa42ccfc3d45786915227c65a9b3d2/redex-lib/redex/private/cycle-check.rkt#L89-L90) of `parent-language-nt-neighbors`, I suspect the fix is simply to lookup `aliases` before using `parent-language-nt-neighbors`.